### PR TITLE
Changed dependency from `rails`to `actionpack`

### DIFF
--- a/axlsx_rails.gemspec
+++ b/axlsx_rails.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + Dir['[A-Z]*'] - ['Guardfile']
   s.test_files = Dir["spec/**/*"] + ['Guardfile']
 
-  s.add_dependency "rails", ">= 3.1"
+  s.add_dependency "actionpack", ">= 3.1"
   s.add_dependency "axlsx", ">= 2.0.1"
 
   s.add_development_dependency "bundler"


### PR DESCRIPTION
axlsx_rails works fine without ActiveRecord. So it shouldn't require the complete Rails but the ActionPack (Controller, Views, ...) instead. 