### PR TITLE
Updated CI ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ env:
   - RAILS_VERSION=5.0
   - RAILS_VERSION=5.1
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
+  - 2.2.10
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 before_install:
   - gem update bundler
 script:


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/03/28/ruby-2-5-1-released/