### PR TITLE
Add missing  method to testing documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ format.xlsx {
 }
 ```
 
-If you use `render xlsx:` the gem will try to guess the file name: 
+If you use `render xlsx:` the gem will try to guess the file name:
 
 ```ruby
 # filename of 'buttons'
@@ -212,7 +212,7 @@ class UserMailer < ActionMailer::Base
 end
 ```
 
-* If the route specifies or suggests the `:xlsx` format you do not need to specify `formats` or `handlers`. 
+* If the route specifies or suggests the `:xlsx` format you do not need to specify `formats` or `handlers`.
 * If the template (`users/export`) can refer to only one file (the xlsx.axlsx template), you do not need to specify `handlers`, provided the `formats` includes `:xlsx`.
 * Specifying the encoding as 'base64' can avoid UTF-8 errors.
 
@@ -240,7 +240,7 @@ RSpec.shared_context 'axlsx' do
   let(:template_path) do
     ['app', 'views', template_name]
   end
-  
+
   # This helper will be used in tests
   def render_template(locals = {})
     axlsx_binding = Kernel.binding
@@ -254,7 +254,7 @@ RSpec.shared_context 'axlsx' do
 
     # mimics an ActionView::Template class, presenting a 'source' method
     # to retrieve the content of the template
-    axlsx_binding.eval(ActionView::Template::Handlers::AxlsxBuilder.call(Struct.new(:source).new(File.read(Rails.root.join(*template_path)))))
+    axlsx_binding.eval(ActionView::Template::Handlers::AxlsxBuilder.new.call(Struct.new(:source).new(File.read(Rails.root.join(*template_path)))))
     axlsx_binding.local_variable_get(:wb)
   end
 end


### PR DESCRIPTION
Hi,
I come across on set  up Rspec for axlsx_rails testing but there is an error I've encounter with `#render_template` method.

This is an error: 
![screen shot 2561-10-24 at 18 35 34](https://user-images.githubusercontent.com/6436298/47428905-e32dfc80-d7be-11e8-854a-beb9b99e563c.png)

After put some effort I finally solve the problem by adding .new before .call  in #render_template method. Here is the result:
![screen shot 2561-10-24 at 18 35 51](https://user-images.githubusercontent.com/6436298/47428978-0b1d6000-d7bf-11e8-8e09-17fc2ef36073.png)

So, I have update the Readme for that fixed.

Thanks.
Natthakit 