### PR TITLE
Update template handler for Rails 6

### DIFF
--- a/lib/axlsx_rails/template_handler.rb
+++ b/lib/axlsx_rails/template_handler.rb
@@ -11,7 +11,7 @@ module ActionView
         Rails.version.to_f >= 5 ? Mime[:xlsx] : Mime::XLSX
       end
 
-      def call(template)
+      def call(template, source = nil)
         builder = StringIO.new
         builder << "require 'axlsx';"
         builder << "xlsx_author = defined?(xlsx_author).nil? ? nil : xlsx_author;"
@@ -21,7 +21,7 @@ module ActionView
         builder << ":author => xlsx_author,"
         builder << ":created_at => xlsx_created_at,"
         builder << ":use_shared_strings => xlsx_use_shared_strings);"
-        builder << template.source
+        builder << source || template.source
         builder << ";xlsx_package.to_stream.string;"
         builder.string
       end

--- a/spec/axlsx_builder_spec.rb
+++ b/spec/axlsx_builder_spec.rb
@@ -21,7 +21,16 @@ describe 'Axlsx template handler' do
       expect(handler.default_format).to eq(mime_type)
     end
 
-    it "compiles to an excel spreadsheet" do
+    it "compiles to an excel spreadsheet when passing in a source" do
+      xlsx_package, wb = nil
+      source = "wb = xlsx_package.workbook;\nwb.add_worksheet(name: 'Test') do |sheet|\n\tsheet.add_row ['four', 'five', 'six']\n\tsheet.add_row ['d', 'e', 'f']\nend\n"
+      eval( AB.new.call template, source )
+      xlsx_package.serialize('/tmp/axlsx_temp.xlsx')
+      expect{ wb = Roo::Excelx.new('/tmp/axlsx_temp.xlsx') }.to_not raise_error
+      expect(wb.cell(2,3)).to eq('c')
+    end
+
+    it "compiles to an excel spreadsheet when inferring source from template " do
       xlsx_package, wb = nil
       eval( AB.new.call template )
       xlsx_package.serialize('/tmp/axlsx_temp.xlsx')


### PR DESCRIPTION
Running axlsx in Rails 6 triggers a deprecation warning:

```
DEPRECATION WARNING: Single arity template handlers are deprecated.  Template handlers must
now accept two parameters, the view object and the source for the view object.
Change:
  >> #<Class:0x000000010f6c1c80>#call(template)
To:
  >> #<Class:0x000000010f6c1c80>#call(template, source)
```

This is because of a recent change to Rails (rails/rails#35119) that attempts to make template handlers read-only.

This PR removes the deprecated (“old-style”) handler for Rails 6 projects, while maintaining compatibility with older versions of Rails.

Fixes #112.